### PR TITLE
feat(153513): integra MS-Concursos para atualizar situação do concurso

### DIFF
--- a/apps/processos/api/views.py
+++ b/apps/processos/api/views.py
@@ -10,8 +10,15 @@ from typing import Any
 from cargos.repository import CargoProcessoRepository
 from django.db.models import QuerySet
 from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework import status, viewsets
+from rest_framework.decorators import action
+from rest_framework.filters import OrderingFilter, SearchFilter
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.serializers import BaseSerializer
+from sigla_sdk.context import get_correlation_id
+
 from processos.constants import (
-    CONCURSO_SITUACAO_EM_ANDAMENTO,
     ERROR_CANDIDATOS_PENDENTES_ESCOLHA,
     ERROR_PROCESSO_JA_CANCELADO,
     ERROR_PROCESSO_JA_FINALIZADO,
@@ -28,20 +35,12 @@ from processos.serializers import (
     ProcessoConvocacaoSerializer,
     ProcessoConvocacaoUpdateSerializer,
 )
-from processos.services import ConcursosApiService, EscolhasApiService
-from processos.services.exceptions import ConcursoServiceError
+from processos.services import EscolhasApiService
 from processos.services.processo_service import (
     ProcessoConvocacaoService,
     ProcessoServiceError,
 )
 from processos.utils import CustomPagination
-from rest_framework import status, viewsets
-from rest_framework.decorators import action
-from rest_framework.filters import OrderingFilter, SearchFilter
-from rest_framework.request import Request
-from rest_framework.response import Response
-from rest_framework.serializers import BaseSerializer
-from sigla_sdk.context import get_correlation_id
 
 logger = logging.getLogger(__name__)
 
@@ -115,24 +114,6 @@ class ProcessoConvocacaoViewSet(viewsets.ModelViewSet):
         elif self.action in ["update", "partial_update"]:
             return ProcessoConvocacaoUpdateSerializer
         return ProcessoConvocacaoSerializer
-
-    def perform_create(self, serializer: BaseSerializer) -> None:
-        """Salva o processo e sinaliza EM_ANDAMENTO para o concurso."""
-        processo = serializer.save()
-        try:
-            ConcursosApiService().atualizar_situacao(
-                concurso_uuid=str(processo.concurso_uuid),
-                situacao=CONCURSO_SITUACAO_EM_ANDAMENTO,
-            )
-        except ConcursoServiceError:
-            logger.exception(
-                "Falha ao atualizar situação do concurso para EM_ANDAMENTO",
-                extra={
-                    "concurso_uuid": str(processo.concurso_uuid),
-                    "processo_uuid": str(processo.uuid),
-                    "correlation_id": get_correlation_id(),
-                },
-            )
 
     def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """Lista processos paginados ou em formato select."""

--- a/apps/processos/api/views.py
+++ b/apps/processos/api/views.py
@@ -11,6 +11,7 @@ from cargos.repository import CargoProcessoRepository
 from django.db.models import QuerySet
 from django_filters.rest_framework import DjangoFilterBackend
 from processos.constants import (
+    CONCURSO_SITUACAO_EM_ANDAMENTO,
     ERROR_CANDIDATOS_PENDENTES_ESCOLHA,
     ERROR_PROCESSO_JA_CANCELADO,
     ERROR_PROCESSO_JA_FINALIZADO,
@@ -27,7 +28,8 @@ from processos.serializers import (
     ProcessoConvocacaoSerializer,
     ProcessoConvocacaoUpdateSerializer,
 )
-from processos.services import EscolhasApiService
+from processos.services import ConcursosApiService, EscolhasApiService
+from processos.services.exceptions import ConcursoServiceError
 from processos.services.processo_service import (
     ProcessoConvocacaoService,
     ProcessoServiceError,
@@ -113,6 +115,24 @@ class ProcessoConvocacaoViewSet(viewsets.ModelViewSet):
         elif self.action in ["update", "partial_update"]:
             return ProcessoConvocacaoUpdateSerializer
         return ProcessoConvocacaoSerializer
+
+    def perform_create(self, serializer: BaseSerializer) -> None:
+        """Salva o processo e sinaliza EM_ANDAMENTO para o concurso."""
+        processo = serializer.save()
+        try:
+            ConcursosApiService().atualizar_situacao(
+                concurso_uuid=str(processo.concurso_uuid),
+                situacao=CONCURSO_SITUACAO_EM_ANDAMENTO,
+            )
+        except ConcursoServiceError:
+            logger.exception(
+                "Falha ao atualizar situação do concurso para EM_ANDAMENTO",
+                extra={
+                    "concurso_uuid": str(processo.concurso_uuid),
+                    "processo_uuid": str(processo.uuid),
+                    "correlation_id": get_correlation_id(),
+                },
+            )
 
     def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """Lista processos paginados ou em formato select."""

--- a/apps/processos/apps.py
+++ b/apps/processos/apps.py
@@ -10,8 +10,9 @@ class ProcessosConfig(AppConfig):
     name = "processos"
 
     def ready(self) -> None:
-        """Importa Celery na inicialização do Django."""
+        """Importa Celery e signals na inicialização do Django."""
         try:  # noqa: SIM105
-            from config import celery_app  # noqa: F401
+            from config import celery_app 
         except Exception:
             pass
+        import processos.signals

--- a/apps/processos/constants.py
+++ b/apps/processos/constants.py
@@ -35,3 +35,6 @@ ERROR_CANDIDATOS_PENDENTES_ESCOLHA = (
     "Existem candidatos convocados que ainda não fizeram escolha."
 )
 ERROR_PROCESSO_NAO_PODE_EDITAR = "Processo finalizado não pode ser alterado."
+
+CONCURSO_SITUACAO_EM_ANDAMENTO = "EM_ANDAMENTO"
+CONCURSO_SITUACAO_COMPLETO = "COMPLETO"

--- a/apps/processos/repository.py
+++ b/apps/processos/repository.py
@@ -132,3 +132,10 @@ class ProcessoConvocacaoRepository:
         CargoProcessoRepository.excluir_por_processo(processo)
         processo.esta_ativo = False
         cls.salvar(processo, campos_atualizacao=["esta_ativo"])
+
+    @classmethod
+    def contar_ativos_por_concurso(cls, concurso_uuid: str | UUID) -> int:
+        """Conta convocações ativas restantes para um concurso."""
+        return ProcessoConvocacao.objects.filter(
+            concurso_uuid=concurso_uuid, esta_ativo=True
+        ).count()

--- a/apps/processos/services/__init__.py
+++ b/apps/processos/services/__init__.py
@@ -4,10 +4,12 @@
 
 from .agenda_api_service import AgendaApiService
 from .candidatos_api_url import CandidatosApiService
+from .concursos_api_service import ConcursosApiService
 from .escolhas_service import EscolhasApiService
 
 __all__ = [
     "AgendaApiService",
     "CandidatosApiService",
+    "ConcursosApiService",
     "EscolhasApiService",
 ]

--- a/apps/processos/services/concursos_api_service.py
+++ b/apps/processos/services/concursos_api_service.py
@@ -1,0 +1,70 @@
+"""Requisições ao MS-Concursos para atualização de situação do concurso."""
+
+import logging
+
+from django.conf import settings
+from processos.services.exceptions import ConcursoServiceError
+from sigla_sdk.context import get_correlation_id
+from sigla_sdk.http.api_client import http_client
+
+logger = logging.getLogger(__name__)
+
+
+class ConcursosApiService:
+    """Define ConcursosApiService."""
+
+    TIMEOUT_SEGUNDOS = 30
+
+    def __init__(self) -> None:
+        """Inicializa cliente HTTP do MS-Concursos."""
+        self.base_url = settings.CONCURSOS_API_URL.rstrip("/")
+        self.timeout_seconds = self.TIMEOUT_SEGUNDOS
+        self.headers: dict[str, str] = {
+            "Accept": "application/json",
+            settings.API_KEY_HEADER: settings.CONCURSOS_API_KEY,
+        }
+
+    def atualizar_situacao(self, concurso_uuid: str, situacao: str) -> dict:
+        """PATCH /api/v1/concursos/<uuid>/atualizar-situacao/."""
+        url = (
+            f"{self.base_url}/api/v1/concursos/"
+            f"{concurso_uuid}/atualizar-situacao/"
+        )
+        payload = {"situacao": situacao}
+        logger.info(
+            "Atualizando situação do concurso no MS-Concursos",
+            extra={
+                "correlation_id": get_correlation_id(),
+                "method": "PATCH",
+                "url": url,
+                "concurso_uuid": concurso_uuid,
+                "situacao": situacao,
+            },
+        )
+        try:
+            resposta = http_client.patch(
+                url,
+                json=payload,
+                headers=self.headers,
+                timeout=self.timeout_seconds,
+            )
+        except Exception as exc:
+            raise ConcursoServiceError(
+                f"Falha ao conectar no MS-Concursos: {str(exc)}"
+            ) from exc
+
+        if resposta.status_code != 200:
+            raise ConcursoServiceError(
+                f"MS-Concursos retornou status {resposta.status_code} "
+                f"ao atualizar situação: {resposta.text}"
+            )
+        logger.info(
+            "Situação do concurso atualizada",
+            extra={
+                "correlation_id": get_correlation_id(),
+                "concurso_uuid": concurso_uuid,
+                "situacao": situacao,
+                "status_code": resposta.status_code,
+            },
+        )
+        return resposta.json() if resposta.content else {}

--- a/apps/processos/services/exceptions.py
+++ b/apps/processos/services/exceptions.py
@@ -9,6 +9,10 @@ class CandidatosServiceError(Exception):
     """Erro ao chamar o MS-Candidatos."""
 
 
+class ConcursoServiceError(Exception):
+    """Erro ao chamar o MS-Concursos."""
+
+
 class EscolhasServiceError(Exception):
     """Erro ao chamar o MS-Escolha."""
 

--- a/apps/processos/services/processo_service.py
+++ b/apps/processos/services/processo_service.py
@@ -10,12 +10,16 @@ from sigla_sdk.context import get_correlation_id
 if TYPE_CHECKING:
     from processos.models import ProcessoConvocacao
 
+from processos.constants import CONCURSO_SITUACAO_COMPLETO
+from processos.repository import ProcessoConvocacaoRepository
 from processos.services.agenda_api_service import AgendaApiService
 from processos.services.candidatos_api_url import CandidatosApiService
+from processos.services.concursos_api_service import ConcursosApiService
 from processos.services.escolhas_service import EscolhasApiService
 from processos.services.exceptions import (
     AgendaServiceError,
     CandidatosServiceError,
+    ConcursoServiceError,
     EscolhasServiceError,
     ProcessoServiceError,
 )
@@ -32,6 +36,7 @@ class ProcessoConvocacaoService:
         agenda_api: AgendaApiService | None = None,
         candidatos_api: CandidatosApiService | None = None,
         escolhas_api: EscolhasApiService | None = None,
+        concursos_api: ConcursosApiService | None = None,
     ) -> None:
         """Inicializa a instância com dependências configuráveis.
 
@@ -40,6 +45,7 @@ class ProcessoConvocacaoService:
             agenda_api: Cliente do MS-Agenda (opcional).
             candidatos_api: Cliente do MS-Candidatos (opcional).
             escolhas_api: Cliente do MS-Escolhas (opcional).
+            concursos_api: Cliente do MS-Concursos (opcional).
 
         Raises:
             Nenhuma exceção específica documentada.
@@ -47,6 +53,7 @@ class ProcessoConvocacaoService:
         self._agenda = agenda_api or AgendaApiService()
         self._candidatos = candidatos_api or CandidatosApiService()
         self._escolhas = escolhas_api or EscolhasApiService()
+        self._concursos = concursos_api or ConcursosApiService()
 
     def excluir_processo_e_dependencias(
         self,
@@ -107,3 +114,22 @@ class ProcessoConvocacaoService:
             raise ProcessoServiceError(str(exc)) from exc
 
         processo.inativar()
+
+        restantes = ProcessoConvocacaoRepository.contar_ativos_por_concurso(
+            processo.concurso_uuid
+        )
+        if restantes == 0:
+            try:
+                self._concursos.atualizar_situacao(
+                    concurso_uuid=str(processo.concurso_uuid),
+                    situacao=CONCURSO_SITUACAO_COMPLETO,
+                )
+            except ConcursoServiceError:
+                logger.exception(
+                    "Falha ao atualizar situação do concurso para COMPLETO",
+                    extra={
+                        "concurso_uuid": str(processo.concurso_uuid),
+                        "processo_uuid": processo_uuid,
+                        "correlation_id": get_correlation_id(),
+                    },
+                )

--- a/apps/processos/signals.py
+++ b/apps/processos/signals.py
@@ -1,0 +1,40 @@
+"""Módulo signals."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from sigla_sdk.context import get_correlation_id
+
+from processos.constants import CONCURSO_SITUACAO_EM_ANDAMENTO
+from processos.models import ProcessoConvocacao
+from processos.services import ConcursosApiService
+from processos.services.exceptions import ConcursoServiceError
+
+logger = logging.getLogger(__name__)
+
+
+@receiver(post_save, sender=ProcessoConvocacao)
+def processo_convocacao_post_save(
+    sender: Any, instance: ProcessoConvocacao, created: bool, **kwargs: Any
+) -> None:
+    """Sinaliza EM_ANDAMENTO ao MS-Concursos quando o processo é criado."""
+    if not created:
+        return
+    try:
+        ConcursosApiService().atualizar_situacao(
+            concurso_uuid=str(instance.concurso_uuid),
+            situacao=CONCURSO_SITUACAO_EM_ANDAMENTO,
+        )
+    except ConcursoServiceError:
+        logger.exception(
+            "Falha ao atualizar situação do concurso para EM_ANDAMENTO",
+            extra={
+                "concurso_uuid": str(instance.concurso_uuid),
+                "processo_uuid": str(instance.uuid),
+                "correlation_id": get_correlation_id(),
+            },
+        )

--- a/apps/processos/tests/services/test_concursos_api_service.py
+++ b/apps/processos/tests/services/test_concursos_api_service.py
@@ -1,0 +1,103 @@
+"""Módulo tests/services/test_concursos_api_service."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from django.test import override_settings
+from processos.services.concursos_api_service import ConcursosApiService
+from processos.services.exceptions import ConcursoServiceError
+
+
+@override_settings(CONCURSOS_API_URL="http://ms-concursos")
+def test_atualizar_situacao_sucesso_retorna_json():
+    """Verifica atualizar situação sucesso retorna json."""
+    service = ConcursosApiService()
+    concurso_uuid = "11111111-1111-1111-1111-111111111111"
+
+    resposta = Mock()
+    resposta.status_code = 200
+    resposta.content = b'{"situacao": "EM_ANDAMENTO"}'
+    resposta.json.return_value = {"situacao": "EM_ANDAMENTO"}
+
+    with patch(
+        "processos.services.concursos_api_service.http_client.patch",
+        return_value=resposta,
+    ) as mock_patch:
+        resultado = service.atualizar_situacao(concurso_uuid, "EM_ANDAMENTO")
+
+    assert resultado == {"situacao": "EM_ANDAMENTO"}
+    mock_patch.assert_called_once()
+    url_chamada = mock_patch.call_args[0][0]
+    kwargs_chamada = mock_patch.call_args.kwargs
+    assert (
+        url_chamada
+        == f"http://ms-concursos/api/v1/concursos/{concurso_uuid}/atualizar-situacao/"  # noqa: E501
+    )
+    assert kwargs_chamada["json"] == {"situacao": "EM_ANDAMENTO"}
+    assert kwargs_chamada["headers"] == service.headers
+    assert kwargs_chamada["timeout"] == service.timeout_seconds
+
+
+@override_settings(
+    CONCURSOS_API_URL="http://ms-concursos",
+    CONCURSOS_API_KEY="test-key",
+    API_KEY_HEADER="X-API-Key",
+)
+def test_atualizar_situacao_envia_api_key():
+    """Verifica envio do header X-API-Key quando CONCURSOS_API_KEY está configurada."""  # noqa: E501
+    service = ConcursosApiService()
+    resposta = Mock()
+    resposta.status_code = 200
+    resposta.content = b"{}"
+    resposta.json.return_value = {}
+
+    with patch(
+        "processos.services.concursos_api_service.http_client.patch",
+        return_value=resposta,
+    ) as mock_patch:
+        service.atualizar_situacao(
+            "22222222-2222-2222-2222-222222222222", "COMPLETO"
+        )
+
+    assert mock_patch.call_args.kwargs["headers"] == {
+        "Accept": "application/json",
+        "X-API-Key": "test-key",
+    }
+
+
+@override_settings(CONCURSOS_API_URL="http://ms-concursos")
+def test_atualizar_situacao_status_diferente_200_gera_erro():
+    """Verifica que status HTTP diferente de 200 gera ConcursoServiceError."""
+    service = ConcursosApiService()
+    resposta = Mock()
+    resposta.status_code = 500
+    resposta.text = "erro"
+    resposta.content = b"erro"
+
+    with patch(  # noqa: SIM117
+        "processos.services.concursos_api_service.http_client.patch",
+        return_value=resposta,
+    ):
+        with pytest.raises(ConcursoServiceError) as exc:
+            service.atualizar_situacao(
+                "33333333-3333-3333-3333-333333333333", "COMPLETO"
+            )
+
+    assert "MS-Concursos retornou status 500" in str(exc.value)
+
+
+@override_settings(CONCURSOS_API_URL="http://ms-concursos")
+def test_atualizar_situacao_excecao_do_client_gera_erro():
+    """Verifica que exceção do client HTTP gera ConcursoServiceError."""
+    service = ConcursosApiService()
+
+    with patch(  # noqa: SIM117
+        "processos.services.concursos_api_service.http_client.patch",
+        side_effect=Exception("boom"),
+    ):
+        with pytest.raises(ConcursoServiceError) as exc:
+            service.atualizar_situacao(
+                "44444444-4444-4444-4444-444444444444", "EM_ANDAMENTO"
+            )
+
+    assert "Falha ao conectar no MS-Concursos" in str(exc.value)

--- a/apps/processos/tests/services/test_processo_service.py
+++ b/apps/processos/tests/services/test_processo_service.py
@@ -1,14 +1,16 @@
 """Módulo tests/services/test_processo_service."""
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from processos.services.agenda_api_service import AgendaApiService
 from processos.services.candidatos_api_url import CandidatosApiService
+from processos.services.concursos_api_service import ConcursosApiService
 from processos.services.escolhas_service import EscolhasApiService
 from processos.services.exceptions import (
     AgendaServiceError,
     CandidatosServiceError,
+    ConcursoServiceError,
     EscolhasServiceError,
     ProcessoServiceError,
 )
@@ -38,7 +40,12 @@ def test_excluir_processo_e_dependencias_sucesso_chama_integracoes_e_inativa():
         escolhas_api=escolhas,
     )
 
-    service.excluir_processo_e_dependencias(processo=processo)
+    with patch(
+        "processos.services.processo_service.ProcessoConvocacaoRepository"
+        ".contar_ativos_por_concurso",
+        return_value=1,
+    ):
+        service.excluir_processo_e_dependencias(processo=processo)
 
     agenda.excluir_agendas_por_processo.assert_called_once_with(
         "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
@@ -128,3 +135,85 @@ def test_excluir_processo_e_dependencias_quando_escolhas_falha_retorna_processo_
     agenda.excluir_agendas_por_processo.assert_called_once()
     candidatos.desconvocar_por_processo.assert_called_once()
     processo.inativar.assert_not_called()
+
+
+def test_excluir_processo_sem_convocacoes_ativas_restantes_atualiza_concurso_para_completo():  # noqa: E501
+    """Reverte concurso para COMPLETO quando não sobra convocação ativa."""
+    agenda = Mock(spec=AgendaApiService)
+    candidatos = Mock(spec=CandidatosApiService)
+    escolhas = Mock(spec=EscolhasApiService)
+    concursos = Mock(spec=ConcursosApiService)
+    processo = _processo_mock("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    processo.concurso_uuid = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+
+    service = ProcessoConvocacaoService(
+        agenda_api=agenda,
+        candidatos_api=candidatos,
+        escolhas_api=escolhas,
+        concursos_api=concursos,
+    )
+
+    with patch(
+        "processos.services.processo_service.ProcessoConvocacaoRepository"
+        ".contar_ativos_por_concurso",
+        return_value=0,
+    ):
+        service.excluir_processo_e_dependencias(processo=processo)
+
+    concursos.atualizar_situacao.assert_called_once_with(
+        concurso_uuid="cccccccc-cccc-cccc-cccc-cccccccccccc",
+        situacao="COMPLETO",
+    )
+
+
+def test_excluir_processo_com_convocacoes_ativas_restantes_nao_atualiza_concurso():  # noqa: E501
+    """Não altera o concurso quando ainda há convocação ativa restante."""
+    agenda = Mock(spec=AgendaApiService)
+    candidatos = Mock(spec=CandidatosApiService)
+    escolhas = Mock(spec=EscolhasApiService)
+    concursos = Mock(spec=ConcursosApiService)
+    processo = _processo_mock()
+    processo.concurso_uuid = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+
+    service = ProcessoConvocacaoService(
+        agenda_api=agenda,
+        candidatos_api=candidatos,
+        escolhas_api=escolhas,
+        concursos_api=concursos,
+    )
+
+    with patch(
+        "processos.services.processo_service.ProcessoConvocacaoRepository"
+        ".contar_ativos_por_concurso",
+        return_value=1,
+    ):
+        service.excluir_processo_e_dependencias(processo=processo)
+
+    concursos.atualizar_situacao.assert_not_called()
+
+
+def test_excluir_processo_quando_atualizar_situacao_concurso_falha_nao_propaga_erro():  # noqa: E501
+    """Falha ao atualizar situação do concurso não aborta a exclusão."""
+    agenda = Mock(spec=AgendaApiService)
+    candidatos = Mock(spec=CandidatosApiService)
+    escolhas = Mock(spec=EscolhasApiService)
+    concursos = Mock(spec=ConcursosApiService)
+    concursos.atualizar_situacao.side_effect = ConcursoServiceError("falhou")
+    processo = _processo_mock()
+    processo.concurso_uuid = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+
+    service = ProcessoConvocacaoService(
+        agenda_api=agenda,
+        candidatos_api=candidatos,
+        escolhas_api=escolhas,
+        concursos_api=concursos,
+    )
+
+    with patch(
+        "processos.services.processo_service.ProcessoConvocacaoRepository"
+        ".contar_ativos_por_concurso",
+        return_value=0,
+    ):
+        service.excluir_processo_e_dependencias(processo=processo)
+
+    processo.inativar.assert_called_once_with()

--- a/apps/processos/tests/test_signals.py
+++ b/apps/processos/tests/test_signals.py
@@ -1,0 +1,76 @@
+"""Módulo tests/test_signals."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+from unittest.mock import Mock, patch
+
+import pytest
+from django.utils import timezone
+
+from processos.models import ProcessoConvocacao
+from processos.services.exceptions import ConcursoServiceError
+
+pytestmark = pytest.mark.django_db
+
+
+def _dados_processo(**overrides: object) -> dict:
+    dados = {
+        "concurso_uuid": uuid.uuid4(),
+        "concurso_nome": "Concurso Teste",
+        "descricao": "Descrição do processo teste",
+        "tipo_escolha": "NOVA_AUTORIZACAO",
+        "status": "EM_ANDAMENTO",
+        "data_convocacao": timezone.now() + timedelta(days=30),
+        "data_corte_vagas": timezone.now() + timedelta(days=5),
+    }
+    dados.update(overrides)
+    return dados
+
+
+def test_signal_chama_atualizacao_situacao_concurso_em_andamento_ao_criar():
+    """Verifica que criar processo dispara atualização de situação."""
+    concurso_uuid = uuid.uuid4()
+
+    with patch("processos.signals.ConcursosApiService") as mock_service_cls:
+        mock_service = Mock()
+        mock_service_cls.return_value = mock_service
+
+        ProcessoConvocacao.objects.create(
+            **_dados_processo(concurso_uuid=concurso_uuid)
+        )
+
+    mock_service.atualizar_situacao.assert_called_once_with(
+        concurso_uuid=str(concurso_uuid), situacao="EM_ANDAMENTO"
+    )
+
+
+def test_signal_nao_falha_quando_atualizacao_situacao_da_erro():
+    """Verifica que falha na chamada a Concursos não impede a criação."""
+    with patch("processos.signals.ConcursosApiService") as mock_service_cls:
+        mock_service = Mock()
+        mock_service.atualizar_situacao.side_effect = ConcursoServiceError(
+            "falhou"
+        )
+        mock_service_cls.return_value = mock_service
+
+        processo = ProcessoConvocacao.objects.create(
+            **_dados_processo(concurso_nome="Novo Concurso 2")
+        )
+
+    assert ProcessoConvocacao.objects.filter(pk=processo.pk).exists()
+
+
+def test_signal_nao_chama_atualizacao_situacao_em_update():
+    """Verifica que salvar update não dispara nova chamada ao concurso."""
+    with patch("processos.signals.ConcursosApiService") as mock_service_cls:
+        mock_service = Mock()
+        mock_service_cls.return_value = mock_service
+        processo = ProcessoConvocacao.objects.create(**_dados_processo())
+        mock_service.atualizar_situacao.reset_mock()
+
+        processo.descricao = "Descrição atualizada"
+        processo.save()
+
+    mock_service.atualizar_situacao.assert_not_called()

--- a/apps/processos/tests/test_views.py
+++ b/apps/processos/tests/test_views.py
@@ -2,7 +2,7 @@
 
 import uuid
 from datetime import timedelta
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from cargos.models import CargoProcesso
@@ -17,6 +17,7 @@ from processos.constants import (
     TIPO_ESCOLHA_CHOICES,
 )
 from processos.models import ProcessoConvocacao
+from processos.services.exceptions import ConcursoServiceError
 from rest_framework import status
 
 pytestmark = pytest.mark.django_db
@@ -157,6 +158,68 @@ def test_processo_convocacao_criacao(authenticated_client):
 
     processo = ProcessoConvocacao.objects.first()
     assert processo.concurso_nome == "Novo Concurso"
+
+
+def test_criar_processo_chama_atualizacao_situacao_concurso_em_andamento(
+    authenticated_client,
+):
+    """Verifica que criar processo dispara atualização de situação."""
+    url = reverse("processoconvocacao-list")
+    concurso_uuid_str = str(uuid.uuid4())
+    dados = {
+        "concurso_uuid": concurso_uuid_str,
+        "concurso_nome": "Novo Concurso",
+        "descricao": "Descrição do novo processo",
+        "tipo_escolha": "NOVA_AUTORIZACAO",
+        "status": "EM_ANDAMENTO",
+        "data_convocacao": (timezone.now() + timedelta(days=30)).isoformat(),
+        "data_corte_vagas": (timezone.now() + timedelta(days=5)).isoformat(),
+    }
+
+    with patch(
+        "processos.api.views.ConcursosApiService"
+    ) as mock_service_cls:
+        mock_service = Mock()
+        mock_service_cls.return_value = mock_service
+
+        resposta = authenticated_client.post(url, dados, format="json")
+
+    assert resposta.status_code == status.HTTP_201_CREATED
+    mock_service.atualizar_situacao.assert_called_once_with(
+        concurso_uuid=concurso_uuid_str, situacao="EM_ANDAMENTO"
+    )
+
+
+def test_criar_processo_nao_falha_quando_atualizacao_situacao_da_erro(
+    authenticated_client,
+):
+    """Verifica que falha na chamada a Concursos não impede a criação."""
+    url = reverse("processoconvocacao-list")
+    dados = {
+        "concurso_uuid": str(uuid.uuid4()),
+        "concurso_nome": "Novo Concurso 2",
+        "descricao": "Descrição do novo processo 2",
+        "tipo_escolha": "NOVA_AUTORIZACAO",
+        "status": "EM_ANDAMENTO",
+        "data_convocacao": (timezone.now() + timedelta(days=30)).isoformat(),
+        "data_corte_vagas": (timezone.now() + timedelta(days=5)).isoformat(),
+    }
+
+    with patch(
+        "processos.api.views.ConcursosApiService"
+    ) as mock_service_cls:
+        mock_service = Mock()
+        mock_service.atualizar_situacao.side_effect = ConcursoServiceError(
+            "falhou"
+        )
+        mock_service_cls.return_value = mock_service
+
+        resposta = authenticated_client.post(url, dados, format="json")
+
+    assert resposta.status_code == status.HTTP_201_CREATED
+    assert ProcessoConvocacao.objects.filter(
+        concurso_nome="Novo Concurso 2"
+    ).exists()
 
 
 def test_processo_convocacao_detalhe(

--- a/apps/processos/tests/test_views.py
+++ b/apps/processos/tests/test_views.py
@@ -2,13 +2,15 @@
 
 import uuid
 from datetime import timedelta
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 from cargos.models import CargoProcesso
 from django.contrib.auth.models import User
 from django.urls import reverse
 from django.utils import timezone
+from rest_framework import status
+
 from processos.constants import (
     ERROR_CANDIDATOS_PENDENTES_ESCOLHA,
     ERROR_PROCESSO_JA_CANCELADO,
@@ -17,8 +19,6 @@ from processos.constants import (
     TIPO_ESCOLHA_CHOICES,
 )
 from processos.models import ProcessoConvocacao
-from processos.services.exceptions import ConcursoServiceError
-from rest_framework import status
 
 pytestmark = pytest.mark.django_db
 
@@ -158,68 +158,6 @@ def test_processo_convocacao_criacao(authenticated_client):
 
     processo = ProcessoConvocacao.objects.first()
     assert processo.concurso_nome == "Novo Concurso"
-
-
-def test_criar_processo_chama_atualizacao_situacao_concurso_em_andamento(
-    authenticated_client,
-):
-    """Verifica que criar processo dispara atualização de situação."""
-    url = reverse("processoconvocacao-list")
-    concurso_uuid_str = str(uuid.uuid4())
-    dados = {
-        "concurso_uuid": concurso_uuid_str,
-        "concurso_nome": "Novo Concurso",
-        "descricao": "Descrição do novo processo",
-        "tipo_escolha": "NOVA_AUTORIZACAO",
-        "status": "EM_ANDAMENTO",
-        "data_convocacao": (timezone.now() + timedelta(days=30)).isoformat(),
-        "data_corte_vagas": (timezone.now() + timedelta(days=5)).isoformat(),
-    }
-
-    with patch(
-        "processos.api.views.ConcursosApiService"
-    ) as mock_service_cls:
-        mock_service = Mock()
-        mock_service_cls.return_value = mock_service
-
-        resposta = authenticated_client.post(url, dados, format="json")
-
-    assert resposta.status_code == status.HTTP_201_CREATED
-    mock_service.atualizar_situacao.assert_called_once_with(
-        concurso_uuid=concurso_uuid_str, situacao="EM_ANDAMENTO"
-    )
-
-
-def test_criar_processo_nao_falha_quando_atualizacao_situacao_da_erro(
-    authenticated_client,
-):
-    """Verifica que falha na chamada a Concursos não impede a criação."""
-    url = reverse("processoconvocacao-list")
-    dados = {
-        "concurso_uuid": str(uuid.uuid4()),
-        "concurso_nome": "Novo Concurso 2",
-        "descricao": "Descrição do novo processo 2",
-        "tipo_escolha": "NOVA_AUTORIZACAO",
-        "status": "EM_ANDAMENTO",
-        "data_convocacao": (timezone.now() + timedelta(days=30)).isoformat(),
-        "data_corte_vagas": (timezone.now() + timedelta(days=5)).isoformat(),
-    }
-
-    with patch(
-        "processos.api.views.ConcursosApiService"
-    ) as mock_service_cls:
-        mock_service = Mock()
-        mock_service.atualizar_situacao.side_effect = ConcursoServiceError(
-            "falhou"
-        )
-        mock_service_cls.return_value = mock_service
-
-        resposta = authenticated_client.post(url, dados, format="json")
-
-    assert resposta.status_code == status.HTTP_201_CREATED
-    assert ProcessoConvocacao.objects.filter(
-        concurso_nome="Novo Concurso 2"
-    ).exists()
 
 
 def test_processo_convocacao_detalhe(
@@ -710,7 +648,6 @@ def test_endpoint_filtros_multiplos_processos(authenticated_client, usuario):
 
 def test_endpoint_filtros_concurso_duplicado(authenticated_client, usuario):
     """Testa que concursos duplicados são removidos no endpoint /filtros/."""
-
     concurso_uuid = uuid.uuid4()
     concurso_nome = "Concurso Duplicado"
 
@@ -724,8 +661,8 @@ def test_endpoint_filtros_concurso_duplicado(authenticated_client, usuario):
     )
 
     ProcessoConvocacao.objects.create(
-        concurso_uuid=concurso_uuid,  
-        concurso_nome=concurso_nome,  
+        concurso_uuid=concurso_uuid,
+        concurso_nome=concurso_nome,
         descricao="Descrição 2",
         tipo_escolha="NOVA_AUTORIZACAO",
         status="EM_ANDAMENTO",

--- a/config/settings.py
+++ b/config/settings.py
@@ -301,6 +301,9 @@ AGENDA_API_KEY = os.environ.get("AGENDA_API_KEY", "api-key-agenda")
 ESCOLHAS_API_URL = os.environ.get("ESCOLHAS_API_URL", "").rstrip("/")
 ESCOLHAS_API_KEY = os.environ.get("ESCOLHAS_API_KEY", "api-key-escolhas")
 
+CONCURSOS_API_URL = os.environ.get("CONCURSOS_API_URL", "").rstrip("/")
+CONCURSOS_API_KEY = os.environ.get("CONCURSOS_API_KEY", "api-key-concursos")
+
 MS_URL = os.environ.get("MS_URL", "").rstrip("/")
 
 JWT_SIGNING_KEY = os.environ.get(


### PR DESCRIPTION
## O que foi feito

- Adiciona `ConcursosApiService` para chamar `PATCH /api/v1/concursos/<uuid>/atualizar-situacao/` no MS-Concursos.
- Ao criar um processo de convocação (`perform_create`), atualiza a situação do concurso para `EM_ANDAMENTO`.
- Ao excluir uma convocação e não restarem convocações ativas para o concurso, atualiza a situação para `COMPLETO` (`contar_ativos_por_concurso` no repository).
- Falhas de comunicação com o MS-Concursos (`ConcursoServiceError`) são capturadas e logadas via `logger.exception`, sem interromper a criação/exclusão do processo.
- Novas configurações `CONCURSOS_API_URL` e `CONCURSOS_API_KEY` em `config/settings.py`.

[AB#153513](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/153513)
[AB#153506](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/153506)